### PR TITLE
Added some checks to handle some resizing problems.

### DIFF
--- a/include/nkimage.hrl
+++ b/include/nkimage.hrl
@@ -23,3 +23,4 @@
 %% ===================================================================
 -define(IMAGE_PROCESSOR, <<"image.processor">>).
 -define(IMAGE_JOB, <<"image.job">>).
+-define(MIN_IMAGE_SIZE, 200000).


### PR DESCRIPTION
Here are the changes:
- Added a first filter to only resize images bigger than 200 KB.
- If its lower, then the image dimensions are compared to the desired values of the resizing. Only if none of them (width nor height) are bigger than our desired values, then the resizing ends with a "thumbnail not needed" error.
- Finally, after the resizing, both the original file and the resized file are compared. If the size of the latter is bigger, then a "thumbnail_bigger" error is returned.